### PR TITLE
fix namespace (and comment out as best practice)

### DIFF
--- a/gitops-applications/advanced-cluster-management.application.yaml
+++ b/gitops-applications/advanced-cluster-management.application.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: hcm-ai-advanced-cluster-management
-  namespace: maas-config
+  # namespace: maas-config
 spec:
   destination:
     name: in-cluster

--- a/gitops-applications/authorino-operator.application.yaml
+++ b/gitops-applications/authorino-operator.application.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: hcm-ai-authorino-operator
-  namespace: maas-config
+  # namespace: maas-config
 spec:
   destination:
     name: in-cluster

--- a/gitops-applications/gpu-operator-certified.application.yaml
+++ b/gitops-applications/gpu-operator-certified.application.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: hcm-ai-gpu-operator-certified
-  namespace: maas-config
+  # namespace: maas-config
 spec:
   destination:
     name: in-cluster

--- a/gitops-applications/inference-service.application.yaml
+++ b/gitops-applications/inference-service.application.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: hcm-ai-inference-service
-  namespace: maas
+  # namespace: maas-config
 spec:
   destination:
     name: in-cluster

--- a/gitops-applications/nfd.application.yaml
+++ b/gitops-applications/nfd.application.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: hcm-ai-nfd
-  namespace: maas-config
+  # namespace: maas-config
 spec:
   destination:
     name: in-cluster

--- a/gitops-applications/rhoai.application.yaml
+++ b/gitops-applications/rhoai.application.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: hcm-ai-rhoai
-  namespace: maas-config
+  # namespace: maas-config
 spec:
   destination:
     name: in-cluster
@@ -16,4 +16,3 @@ spec:
       selfHeal: true
       allowEmpty: false
     prune: false
-

--- a/gitops-applications/serverless-operator.application.yaml
+++ b/gitops-applications/serverless-operator.application.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: hcm-ai-serverless-operator
-  namespace: maas-config
+  # namespace: maas-config
 spec:
   destination:
     name: in-cluster

--- a/gitops-applications/servicemeshoperator.application.yaml
+++ b/gitops-applications/servicemeshoperator.application.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: hcm-ai-servicemesh-operator
-  namespace: maas-config
+  # namespace: maas-config
 spec:
   destination:
     name: in-cluster


### PR DESCRIPTION
the inference app was tyargeting `maas` while tryign to be deployed on `maas-config`. Leading to 
```
... error: the namespace from the provided object "maas" does not match the namespace "maas-config". You must pass '--namespace=maas' to perform this operation.
 (error details: https://github.com/app-sre/hcm-ai-playground/tree/main/gitops-applications)
 ```
 
 as a best practice, commenting out `namespace` fields. Though I am not sure if that will break other deployment types on @gurnben 's cluster. TBC