### PR TITLE
Add clusterrole for accessing all inference services

### DIFF
--- a/inference-service/clusterrole.yaml
+++ b/inference-service/clusterrole.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: inference-service-access
+  labels:
+    opendatahub.io/dashboard: 'true'
+rules:
+  - verbs:
+      - list
+      - get
+      - watch
+    apiGroups:
+      - serving.kserve.io
+    resources:
+      - inferenceservices

--- a/inference-service/kustomization.yaml
+++ b/inference-service/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./mistral-small
   - ./llama-scout
   - namespace.yaml
+  - clusterrole.yaml


### PR DESCRIPTION
Adding a ClusterRole that can get/list/watch all 'inferenceservice' objects. We'll then grant users access to this ClusterRole.

In future we may have more granular access to the specific inferenceservices. The intent of this one would be to allow access to all of them.