### PR TITLE
Add Qwen3-32B model inference service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This repository contains the ArgoCD (GitOps) applications and Kubernetes manifests that define the HCM AI Playground platform. The platform provides hosted models via inference services, OpenShift AI for model refinement and RAGs, all in a managed environment.
+
+## Architecture
+
+The platform is structured around several key components:
+
+### GitOps Applications (`gitops-applications/`)
+ArgoCD applications that orchestrate the deployment of operators and workloads:
+- `rhoai.application.yaml` - Red Hat OpenShift AI platform deployment
+- `inference-service.application.yaml` - Model inference services (Mistral, LLama)
+- `gpu-operator-certified.application.yaml` - NVIDIA GPU operator for GPU acceleration
+- `advanced-cluster-management.application.yaml` - Multi-cluster management
+- `serverless-operator.application.yaml` - Knative serverless platform
+- `authorino-operator.application.yaml` - API authorization and authentication
+
+### Operators (`operators/`)
+Kustomize-based operator deployments adapted from the GitOps Catalog:
+- `rhods-operator/` - Red Hat OpenShift Data Science platform with overlays for different versions (fast, eus-2.16, etc.)
+- `gpu-operator-certified/` - NVIDIA GPU operator with AWS and OpenShift-specific configurations
+- `advanced-cluster-management/` - Multi-cluster management across versions 2.8-2.13
+- `serverless-operator/` - Knative serving and eventing
+- `authorino-operator/` - Authorization service
+
+### Inference Services (`inference-service/`)
+Model serving configurations:
+- `mistral-small/` - Mistral small model serving runtime
+- `llama-scout/` - Llama model serving runtime
+- Each service includes RBAC, service accounts, and inference service definitions
+
+### Platform Services
+- `llama-stack/` - Llama Stack deployment with Authorino authentication and Envoy proxy
+- `grafana-dev/` - Development Grafana instance for monitoring
+- `patch/argocd-permissions/` - RBAC permissions for ArgoCD service accounts
+
+## Key Deployment Patterns
+
+### Kustomize Structure
+All components use Kustomize with a base/overlays pattern:
+- `base/` - Core resource definitions
+- `overlays/` - Environment-specific customizations
+- `components/` - Optional feature additions
+
+### Environment Overlays
+Operators support multiple deployment channels:
+- `fast/` - Latest development versions
+- `stable/` - Production-ready versions
+- `eus-X.Y/` - Extended Update Support versions
+- Environment-specific configurations (e.g., `hcmaii01ue1/`, `rehoboam/`)
+
+### GitOps Integration
+All applications reference `https://github.com/app-sre/hcm-ai-playground` as the source repository with `main` branch as target revision.
+
+## Important Configuration Notes
+
+### GPU Configuration
+- GPU operators are configured for OpenShift and AWS environments
+- Time-slicing configurations available for GPU sharing (2-way, 4-way)
+- MIG (Multi-Instance GPU) support for enterprise GPUs
+
+### Authentication & Authorization
+- Authorino provides API-level authorization
+- Service mesh integration for secure communications
+- OAuth client configurations for dashboard access
+
+### Model Management
+- Models are stored in S3-compatible storage
+- The `scripts/upload-from-hf-to-s3-stream.py` utility transfers models from HuggingFace to S3
+- Required environment variables: `MODELS_AWS_ACCESS_KEY_ID`, `MODELS_AWS_SECRET_ACCESS_KEY`, `MODELS_HF_TOKEN`, `MODELS_BUCKET_NAME`, `MODELS_PATH`
+
+## Common Operations
+
+### Deploying the Platform
+1. Apply ArgoCD permissions: `oc apply -k patch/argocd-permissions/`
+2. Deploy all applications: `oc apply -f gitops-applications/*.yaml`
+3. Monitor deployments via ArgoCD UI
+
+### Adding New Models
+1. Create new directory under `inference-service/`
+2. Include: `kustomization.yaml`, `inference-service.yaml`, `serving-runtime.yaml`, RBAC manifests
+3. Update main `inference-service/kustomization.yaml` to include new model
+4. Create corresponding ArgoCD application if needed
+
+### Environment-Specific Deployments
+Use Kustomize overlays to customize for specific environments:
+- Reference appropriate overlay path in ArgoCD applications
+- Environment configurations stored in `overlays/<environment>/`
+
+### Model Upload Utility
+Use the HuggingFace to S3 streaming script:
+```bash
+python scripts/upload-from-hf-to-s3-stream.py <repo_id>
+```
+
+## Repository Maintenance
+
+### Adding Operators
+1. Check [GitOps Catalog](https://github.com/redhat-cop/gitops-catalog/) for existing definitions
+2. Create operator directory structure under `operators/`
+3. Create corresponding ArgoCD application in `gitops-applications/`
+
+### Updating Operator Versions
+Modify the `patch-channel.yaml` files in overlay directories to change operator channels/versions.
+
+### Security Considerations
+- Secrets are managed via sealed-secrets or external secret management
+- Service accounts follow principle of least privilege
+- Network policies control inter-service communication

--- a/inference-service/kustomization.yaml
+++ b/inference-service/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   # - ./mistral-small-dev 
   - ./mistral-small
   - ./llama-scout
+  - ./qwen3-32b
   - namespace.yaml
   - clusterrole.yaml
   - role.yaml

--- a/inference-service/qwen3-32b/default-qwen3-sa.secret.yaml
+++ b/inference-service/qwen3-32b/default-qwen3-sa.secret.yaml
@@ -1,0 +1,11 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: default-qwen3-32b-maas-sa
+  namespace: maas
+  labels:
+    opendatahub.io/dashboard: "true"
+  annotations:
+    kubernetes.io/service-account.name: qwen3-32b-maas-sa
+    openshift.io/display-name: default
+type: kubernetes.io/service-account-token

--- a/inference-service/qwen3-32b/default-sa.sa.yaml
+++ b/inference-service/qwen3-32b/default-sa.sa.yaml
@@ -1,0 +1,5 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: qwen3-32b-maas-sa
+  namespace: maas

--- a/inference-service/qwen3-32b/inference-service.yaml
+++ b/inference-service/qwen3-32b/inference-service.yaml
@@ -1,0 +1,54 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    openshift.io/display-name: qwen3-32b-maas
+    security.opendatahub.io/enable-auth: 'true'
+    serving.knative.openshift.io/enablePassthrough: 'true'
+    serving.kserve.io/deploymentMode: Serverless
+    sidecar.istio.io/inject: 'true'
+    sidecar.istio.io/rewriteAppHTTPProbers: 'true'
+  name: qwen3-32b-maas
+  namespace: maas
+  finalizers:
+    - inferenceservice.finalizers
+    - odh.inferenceservice.finalizers
+  labels:
+    opendatahub.io/dashboard: 'true'
+spec:
+  predictor:
+    maxReplicas: 1
+    minReplicas: 1
+    model:
+      args:
+        - '--max-model-len'
+        - '32768'
+        - '--tensor-parallel-size'
+        - '4'
+        - '--enable-auto-tool-choice'
+        - '--tool-call-parser'
+        - 'hermes'
+      modelFormat:
+        name: vLLM
+      name: ''
+      resources:
+        limits:
+          nvidia.com/gpu: '4'
+        requests:
+          cpu: '4'
+          memory: 32Gi
+          nvidia.com/gpu: '4'
+      runtime: qwen3-32b-maas
+      storage:
+        key: models
+        path: models-maas/models--Qwen--Qwen3-32B/
+    tolerations:
+      - effect: NoSchedule
+        key: nvidia-gpu-only
+        operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Equal
+        value: L4
+    annotations:
+      serving.knative.dev/progress-deadline: 30m

--- a/inference-service/qwen3-32b/kustomization.yaml
+++ b/inference-service/qwen3-32b/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - inference-service.yaml
+  - serving-runtime.yaml
+  - default-qwen3-sa.secret.yaml
+  - default-sa.sa.yaml
+  - role.yaml
+  - role-binding.yaml

--- a/inference-service/qwen3-32b/role-binding.yaml
+++ b/inference-service/qwen3-32b/role-binding.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: qwen3-32b-maas-view
+  namespace: maas
+  labels:
+    opendatahub.io/dashboard: 'true'
+subjects:
+  - kind: ServiceAccount
+    name: qwen3-32b-maas-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: qwen3-32b-maas-view-role

--- a/inference-service/qwen3-32b/role.yaml
+++ b/inference-service/qwen3-32b/role.yaml
@@ -1,0 +1,16 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: qwen3-32b-maas-view-role
+  namespace: maas
+  labels:
+    opendatahub.io/dashboard: 'true'
+rules:
+  - verbs:
+      - get
+    apiGroups:
+      - serving.kserve.io
+    resources:
+      - inferenceservices
+    resourceNames:
+      - qwen3-32b-maas

--- a/inference-service/qwen3-32b/serving-runtime.yaml
+++ b/inference-service/qwen3-32b/serving-runtime.yaml
@@ -1,0 +1,50 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  annotations:
+    opendatahub.io/accelerator-name: nvidia-gpu-l4
+    opendatahub.io/apiProtocol: REST
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+    opendatahub.io/template-display-name: vLLM ServingRuntime for KServe
+    opendatahub.io/template-name: vllm-runtime
+    openshift.io/display-name: qwen3-32b-maas
+  name: qwen3-32b-maas
+  namespace: maas
+  labels:
+    opendatahub.io/dashboard: 'true'
+spec:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: '8080'
+  containers:
+    - args:
+        - '--port=8080'
+        - '--model=/mnt/models'
+        - '--served-model-name={{.Name}}'
+        - '--tensor-parallel-size=4'
+      command:
+        - python
+        - '-m'
+        - vllm.entrypoints.openai.api_server
+      env:
+        - name: HF_HOME
+          value: /tmp/hf_home
+        - name: TRANSFORMERS_CACHE
+          value: /tmp/transformers_cache
+      image: 'quay.io/vllm/vllm:0.8.3.0rc0'
+      name: kserve-container
+      ports:
+        - containerPort: 8080
+          protocol: TCP
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: shm
+  multiModel: false
+  supportedModelFormats:
+    - autoSelect: true
+      name: vLLM
+  volumes:
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 4Gi
+      name: shm


### PR DESCRIPTION
## Summary
- Add new inference service deployment for Qwen/Qwen3-32B model
- Configure vLLM runtime with 4-GPU tensor parallelism for optimal performance
- Include complete RBAC setup with service accounts and permissions
- Support for 32K context length native to the Qwen3 architecture
- Add CLAUDE.md documentation for future development guidance

## Changes Made
- Created `inference-service/qwen3-32b/` directory with complete deployment configuration
- Updated main `inference-service/kustomization.yaml` to include the new model
- Configured for 32B parameter model requiring 4 GPUs and 32Gi memory
- Set up proper service mesh integration and authentication

## Test Plan
- [ ] Verify ArgoCD can sync the new inference service configuration
- [ ] Upload Qwen3-32B model to S3 using `scripts/upload-from-hf-to-s3-stream.py Qwen/Qwen3-32B`
- [ ] Test model deployment and inference endpoint availability
- [ ] Validate GPU resource allocation and tensor parallelism configuration
- [ ] Confirm proper authentication and authorization through service mesh

🤖 Generated with [Claude Code](https://claude.ai/code)