### PR TITLE
Switch qwen3-32b model to OpenAI GPT-OSS-120B

### DIFF
--- a/inference-service/qwen3-32b/inference-service.yaml
+++ b/inference-service/qwen3-32b/inference-service.yaml
@@ -22,12 +22,10 @@ spec:
     model:
       args:
         - '--max-model-len'
-        - '262140'
+        - '128000'
         - '--tensor-parallel-size'
         - '4'
         - '--enable-auto-tool-choice'
-        - '--tool-call-parser'
-        - 'hermes'
       modelFormat:
         name: vLLM
       name: ''

--- a/inference-service/qwen3-32b/inference-service.yaml
+++ b/inference-service/qwen3-32b/inference-service.yaml
@@ -2,13 +2,13 @@ apiVersion: serving.kserve.io/v1beta1
 kind: InferenceService
 metadata:
   annotations:
-    openshift.io/display-name: qwen3-32b-maas
+    openshift.io/display-name: gpt-oss-120b-maas
     security.opendatahub.io/enable-auth: 'true'
     serving.knative.openshift.io/enablePassthrough: 'true'
     serving.kserve.io/deploymentMode: Serverless
     sidecar.istio.io/inject: 'true'
     sidecar.istio.io/rewriteAppHTTPProbers: 'true'
-  name: qwen3-32b-maas
+  name: gpt-oss-120b-maas
   namespace: maas
   finalizers:
     - inferenceservice.finalizers
@@ -38,10 +38,10 @@ spec:
           cpu: '4'
           memory: 32Gi
           nvidia.com/gpu: '4'
-      runtime: qwen3-32b-maas
+      runtime: gpt-oss-120b-maas
       storage:
         key: models
-        path: models-maas/models--qwen--Qwen-32B
+        path: models-maas/models--openai--gpt-oss-120b
     tolerations:
       - effect: NoSchedule
         key: nvidia-gpu-only

--- a/inference-service/qwen3-32b/serving-runtime.yaml
+++ b/inference-service/qwen3-32b/serving-runtime.yaml
@@ -7,8 +7,8 @@ metadata:
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
     opendatahub.io/template-display-name: vLLM ServingRuntime for KServe
     opendatahub.io/template-name: vllm-runtime
-    openshift.io/display-name: qwen3-32b-maas
-  name: qwen3-32b-maas
+    openshift.io/display-name: gpt-oss-120b-maas
+  name: gpt-oss-120b-maas
   namespace: maas
   labels:
     opendatahub.io/dashboard: 'true'


### PR DESCRIPTION
- Update model path from models--qwen--Qwen-32B to models--openai--gpt-oss-120b
- Change service and runtime names from qwen3-32b-maas to gpt-oss-120b-maas
- Maintain 4-GPU tensor parallelism configuration for L40S hardware
- Keep original memory requests for proper Kubernetes scheduling

🤖 Generated with [Claude Code](https://claude.ai/code)

@psav I'm just guessing here, but wanted to get the ball rolling.