### PR TITLE
Update oss-120b model to oss-20b with optimized resource allocation

### DIFF
--- a/inference-service/qwen3-32b/inference-service.yaml
+++ b/inference-service/qwen3-32b/inference-service.yaml
@@ -2,13 +2,13 @@ apiVersion: serving.kserve.io/v1beta1
 kind: InferenceService
 metadata:
   annotations:
-    openshift.io/display-name: gpt-oss-120b-maas
+    openshift.io/display-name: gpt-oss-20b-maas
     security.opendatahub.io/enable-auth: 'true'
     serving.knative.openshift.io/enablePassthrough: 'true'
     serving.kserve.io/deploymentMode: Serverless
     sidecar.istio.io/inject: 'true'
     sidecar.istio.io/rewriteAppHTTPProbers: 'true'
-  name: gpt-oss-120b-maas
+  name: gpt-oss-20b-maas
   namespace: maas
   finalizers:
     - inferenceservice.finalizers
@@ -23,22 +23,20 @@ spec:
       args:
         - '--max-model-len'
         - '128000'
-        - '--tensor-parallel-size'
-        - '4'
       modelFormat:
         name: vLLM
       name: ''
       resources:
         limits:
-          nvidia.com/gpu: '4'
+          nvidia.com/gpu: '1'
         requests:
           cpu: '4'
-          memory: 32Gi
-          nvidia.com/gpu: '4'
-      runtime: gpt-oss-120b-maas
+          memory: 16Gi
+          nvidia.com/gpu: '1'
+      runtime: gpt-oss-20b-maas
       storage:
         key: models
-        path: models-maas/models--openai--gpt-oss-120b
+        path: models-maas/models--openai--gpt-oss-20b
     tolerations:
       - effect: NoSchedule
         key: nvidia-gpu-only

--- a/inference-service/qwen3-32b/serving-runtime.yaml
+++ b/inference-service/qwen3-32b/serving-runtime.yaml
@@ -7,8 +7,8 @@ metadata:
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
     opendatahub.io/template-display-name: vLLM ServingRuntime for KServe
     opendatahub.io/template-name: vllm-runtime
-    openshift.io/display-name: gpt-oss-120b-maas
-  name: gpt-oss-120b-maas
+    openshift.io/display-name: gpt-oss-20b-maas
+  name: gpt-oss-20b-maas
   namespace: maas
   labels:
     opendatahub.io/dashboard: 'true'
@@ -21,7 +21,6 @@ spec:
         - '--port=8080'
         - '--model=/mnt/models'
         - '--served-model-name={{.Name}}'
-        - '--tensor-parallel-size=4'
       command:
         - python
         - '-m'
@@ -46,5 +45,5 @@ spec:
   volumes:
     - emptyDir:
         medium: Memory
-        sizeLimit: 4Gi
+        sizeLimit: 2Gi
       name: shm


### PR DESCRIPTION
- Updated storage path from models--openai--gpt-oss-120b to models--openai--gpt-oss-20b
- Removed tensor parallelism (--tensor-parallel-size=4) as 20b model fits on single GPU
- Reduced GPU allocation from 4 to 1 GPUs
- Reduced memory allocation from 32Gi to 16Gi
- Reduced shared memory from 4Gi to 2Gi
- Updated display names and service identifiers

🤖 Generated with [Claude Code](https://claude.ai/code)