### PR TITLE
Apply nvidia-smi PATH fix to default overlay used by ArgoCD

### DIFF
--- a/operators/gpu-operator-certified/instance/overlays/default/kustomization.yaml
+++ b/operators/gpu-operator-certified/instance/overlays/default/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 
 resources:
   - ../../base
+
+patchesStrategicMerge:
+  - patch-gpu-cluster-policy-validator-path.yaml

--- a/operators/gpu-operator-certified/instance/overlays/default/patch-gpu-cluster-policy-validator-path.yaml
+++ b/operators/gpu-operator-certified/instance/overlays/default/patch-gpu-cluster-policy-validator-path.yaml
@@ -1,0 +1,15 @@
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: gpu-cluster-policy
+spec:
+  validator:
+    env:
+      - name: PATH
+        value: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/run/nvidia/driver/usr/bin'
+    plugin:
+      env:
+        - name: WITH_WORKLOAD
+          value: 'false'
+        - name: PATH
+          value: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/run/nvidia/driver/usr/bin'


### PR DESCRIPTION
## Summary
- Applied the nvidia-smi PATH fix to the correct `default` overlay that ArgoCD actually deploys
- Previous PR #33 applied the fix to the `aws` overlay, but ArgoCD uses `instance/overlays/default`
- This ensures the PATH environment variable fix reaches the deployed GPU operator validator containers

## Root Cause
The ArgoCD application `gpu-operator-certified.application.yaml` points to:
```
path: operators/gpu-operator-certified/aggregate/overlays/openshift
```
Which references `../../../instance/overlays/default`, not the `aws` overlay where the previous fix was applied.

## Changes
- Added `patch-gpu-cluster-policy-validator-path.yaml` to `instance/overlays/default/`
- Updated `default/kustomization.yaml` to apply the PATH patch
- Same PATH fix as before: includes `/run/nvidia/driver/usr/bin` where nvidia-smi is installed

## Test plan
- [ ] Verify ArgoCD sync applies the updated configuration
- [ ] Confirm GPU operator validator pods can find nvidia-smi
- [ ] Check that validator containers complete initialization successfully

🤖 Generated with [Claude Code](https://claude.ai/code)