### PR TITLE
feat: add agent-swarm ArgoCD application and kustomize payload

### DIFF
--- a/agent-swarm/base/deployment.yaml
+++ b/agent-swarm/base/deployment.yaml
@@ -1,0 +1,60 @@
+# Deployment base — image and env placeholders are set via overlays.
+# Requires a pre-existing Secret "swarmer-secret" with key SWARMER_SECRET_KEY.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: swarmer
+  labels:
+    app: swarmer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: swarmer
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: swarmer
+    spec:
+      serviceAccountName: swarmer
+      containers:
+        - name: swarmer
+          image: SWARMER_IMAGE
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: K8S_IN_CLUSTER
+              value: "true"
+            - name: DATABASE_URL
+              value: sqlite+aiosqlite:////data/swarmer.db
+            - name: SWARMER_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: swarmer-secret
+                  key: SWARMER_SECRET_KEY
+            - name: K8S_API_URL
+              value: "https://kubernetes.default.svc"
+          volumeMounts:
+            - name: swarmer-data
+              mountPath: /data
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "1000m"
+          readinessProbe:
+            httpGet:
+              path: /login
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: swarmer-data
+          persistentVolumeClaim:
+            claimName: swarmer-data

--- a/agent-swarm/base/kustomization.yaml
+++ b/agent-swarm/base/kustomization.yaml
@@ -1,0 +1,22 @@
+# agent-swarm cluster-admin base — multi-namespace deployment.
+# Copied from stolostron/agent-swarm kustomize/base/cluster-admin + common.
+# Requires cluster-admin for ClusterRole, ClusterRoleBinding, Namespace,
+# and OAuthClient creation.
+#
+# Pre-requisites (one-time, manual):
+#   1. Secret "swarmer-secret" with key SWARMER_SECRET_KEY in the swarmer namespace.
+#   2. A pre-built swarmer container image (image placeholder set via overlay).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: swarmer
+
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - rbac.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - route.yaml
+  - oauth-client.yaml

--- a/agent-swarm/base/namespace.yaml
+++ b/agent-swarm/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: swarmer
+  labels:
+    app.kubernetes.io/name: swarmer

--- a/agent-swarm/base/oauth-client.yaml
+++ b/agent-swarm/base/oauth-client.yaml
@@ -1,0 +1,13 @@
+# OAuthClient is cluster-scoped (no namespace).
+# Requires cluster-admin to create.
+# SWARMER_HOST must be replaced with the actual Route hostname via overlay.
+apiVersion: oauth.openshift.io/v1
+kind: OAuthClient
+metadata:
+  name: swarmer
+redirectURIs:
+  - https://SWARMER_HOST/auth/callback
+  - http://localhost:8080/auth/callback
+grantMethod: auto
+responseTypes:
+  - token

--- a/agent-swarm/base/pvc.yaml
+++ b/agent-swarm/base/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: swarmer-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/agent-swarm/base/rbac.yaml
+++ b/agent-swarm/base/rbac.yaml
@@ -1,0 +1,64 @@
+---
+# ClusterRole: swarmer must manage resources across ALL workspace namespaces,
+# not just its own — it creates namespaces, secrets, PVCs, pods and services
+# on behalf of the user.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: swarmer
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/exec", "pods/portforward"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "update", "patch", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterrolebindings"]
+    verbs: ["get", "create", "update", "patch", "delete"]
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: swarmer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: swarmer
+subjects:
+  - kind: ServiceAccount
+    name: swarmer
+    namespace: swarmer
+---
+# Minimal ClusterRole for swarmer dashboard users.
+# Bind via RoleBinding in workspace namespaces to grant user visibility.
+# Use: make grant-workspace SA_USER=<name> WORKSPACE_NS=<namespace>
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: swarmer-user
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]

--- a/agent-swarm/base/route.yaml
+++ b/agent-swarm/base/route.yaml
@@ -1,0 +1,13 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: swarmer
+spec:
+  to:
+    kind: Service
+    name: swarmer
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/agent-swarm/base/service.yaml
+++ b/agent-swarm/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: swarmer
+spec:
+  type: ClusterIP
+  selector:
+    app: swarmer
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http

--- a/agent-swarm/base/serviceaccount.yaml
+++ b/agent-swarm/base/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: swarmer

--- a/agent-swarm/overlays/hcmaii/kustomization.yaml
+++ b/agent-swarm/overlays/hcmaii/kustomization.yaml
@@ -1,0 +1,46 @@
+# hcmaii cluster overlay for agent-swarm (multi-namespace / cluster-admin mode).
+#
+# Pre-requisites (one-time, manual):
+#   1. Create the swarmer-secret in the swarmer namespace:
+#        oc create secret generic swarmer-secret \
+#          --from-literal=SWARMER_SECRET_KEY=$(python3 -c \
+#            "import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())") \
+#          -n swarmer --dry-run=client -o yaml | oc apply -f -
+#
+#   2. After first sync, patch the OAuthClient redirect URI and set OPENSHIFT_OAUTH_URL:
+#        SWARMER_HOST=$(oc get route swarmer -n swarmer -o jsonpath='{.spec.host}')
+#        oc patch oauthclient swarmer --type=json \
+#          -p "[{\"op\":\"replace\",\"path\":\"/redirectURIs/0\",\"value\":\"https://${SWARMER_HOST}/auth/callback\"}]"
+#        oc set env deployment/swarmer -n swarmer \
+#          OPENSHIFT_OAUTH_URL=https://$(oc get route oauth-openshift -n openshift-authentication -o jsonpath='{.spec.host}')
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+images:
+  - name: SWARMER_IMAGE
+    newName: quay.io/jpacker/swarmer
+    newTag: latest
+
+patches:
+  - target:
+      kind: Deployment
+      name: swarmer
+    patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: AGENT_IMAGE_OPENCODE
+          value: "quay.io/jpacker/opencode:0.1.1"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: AGENT_IMAGE_CRUSH
+          value: "ghcr.io/gurnben/crush-container:latest"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: DEFAULT_AGENT_TOOL
+          value: "opencode"

--- a/gitops-applications/agent-swarm.application.yaml
+++ b/gitops-applications/agent-swarm.application.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hcm-ai-agent-swarm
+  namespace: maas-config
+spec:
+  destination:
+    name: in-cluster
+  project: default
+  source:
+    path: agent-swarm/overlays/hcmaii
+    repoURL: 'https://github.com/app-sre/hcm-ai-playground'
+    targetRevision: main
+  syncPolicy:
+    automated:
+      selfHeal: true
+      allowEmpty: false
+    prune: false


### PR DESCRIPTION
## Summary

- Deploy [agent-swarm](https://github.com/stolostron/agent-swarm) (swarmer) to the hcmaii cluster in **multi-namespace (cluster-admin) mode** via a new ArgoCD Application and kustomize payload.
- The kustomize base is copied from `stolostron/agent-swarm`'s `kustomize/base/cluster-admin` + `common` directories and the `hcmaii` overlay sets the container image (`quay.io/jpacker/swarmer:latest`) and agent tool environment variables (`AGENT_IMAGE_OPENCODE`, `AGENT_IMAGE_CRUSH`, `DEFAULT_AGENT_TOOL`).

## New files

| Path | Purpose |
|------|---------|
| `agent-swarm/base/*` (9 files) | Kustomize base — Namespace, ServiceAccount, ClusterRole/Binding, Deployment, PVC, Service, Route, OAuthClient |
| `agent-swarm/overlays/hcmaii/kustomization.yaml` | hcmaii overlay — image + env var configuration |
| `gitops-applications/agent-swarm.application.yaml` | ArgoCD Application with automated selfHeal sync |

## Post-deploy steps (one-time, manual)

1. Create the `swarmer-secret` in the `swarmer` namespace:
   ```bash
   oc create secret generic swarmer-secret \
     --from-literal=SWARMER_SECRET_KEY=$(python3 -c "import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())") \
     -n swarmer --dry-run=client -o yaml | oc apply -f -
   ```
2. After first sync, patch the OAuthClient redirect URI and set `OPENSHIFT_OAUTH_URL`:
   ```bash
   SWARMER_HOST=$(oc get route swarmer -n swarmer -o jsonpath='{.spec.host}')
   oc patch oauthclient swarmer --type=json \
     -p "[{\"op\":\"replace\",\"path\":\"/redirectURIs/0\",\"value\":\"https://${SWARMER_HOST}/auth/callback\"}]"
   oc set env deployment/swarmer -n swarmer \
     OPENSHIFT_OAUTH_URL=https://$(oc get route oauth-openshift -n openshift-authentication -o jsonpath='{.spec.host}')
   ```

## Test plan

- [x] `oc kustomize agent-swarm/overlays/hcmaii` builds successfully and renders all expected resources
- [ ] ArgoCD syncs the application to the hcmaii cluster without errors
- [ ] Swarmer pod starts and becomes ready after secret creation
- [ ] OAuthClient redirect URI patched and login flow works


💘 Generated with Crush