### PR TITLE
fix: strip namespace from OAuthClient to prevent perpetual OutOfSync

### DIFF
--- a/agent-swarm/overlays/hcmaii/kustomization.yaml
+++ b/agent-swarm/overlays/hcmaii/kustomization.yaml
@@ -44,3 +44,11 @@ patches:
         value:
           name: DEFAULT_AGENT_TOOL
           value: "opencode"
+  - target:
+      group: oauth.openshift.io
+      version: v1
+      kind: OAuthClient
+      name: swarmer
+    patch: |
+      - op: remove
+        path: /metadata/namespace


### PR DESCRIPTION
## Summary

- OAuthClient is cluster-scoped, but kustomize's `namespace: swarmer` transformer injects a `namespace` field into it, causing a perpetual OutOfSync diff in ArgoCD.
- Adds a JSON patch in the hcmaii overlay to `remove /metadata/namespace` from the OAuthClient after kustomize renders it.

## Context

Follow-up to #40 and #41. The Route and all other resources are now Synced after the RBAC fix, but the OAuthClient stays OutOfSync due to the namespace mismatch.

## Test plan

- [x] `oc kustomize agent-swarm/overlays/hcmaii` renders OAuthClient without `namespace` field
- [ ] `hcm-ai-agent-swarm` OAuthClient transitions to Synced after this merges


💘 Generated with Crush