### PR TITLE
fix: use versioned image tag 0.4.0 instead of latest

### DIFF
--- a/agent-swarm/overlays/hcmaii/kustomization.yaml
+++ b/agent-swarm/overlays/hcmaii/kustomization.yaml
@@ -22,7 +22,7 @@ resources:
 images:
   - name: SWARMER_IMAGE
     newName: quay.io/jpacker/swarmer
-    newTag: latest
+    newTag: "0.4.0"
 
 patches:
   - target:


### PR DESCRIPTION
## Summary

- `quay.io/jpacker/swarmer` does not publish a `:latest` tag — only versioned tags (e.g. `0.4.0`). The deployment is stuck in `ImagePullBackOff`.
- Updates the overlay image tag from `latest` to `0.4.0`.

## Test plan

- [ ] Pod pulls `quay.io/jpacker/swarmer:0.4.0` successfully and becomes Ready


💘 Generated with Crush