### PR TITLE
fix: set OAuthClient redirect URI and OPENSHIFT_OAUTH_URL in overlay

### DIFF
--- a/agent-swarm/overlays/hcmaii/kustomization.yaml
+++ b/agent-swarm/overlays/hcmaii/kustomization.yaml
@@ -1,18 +1,11 @@
 # hcmaii cluster overlay for agent-swarm (multi-namespace / cluster-admin mode).
 #
-# Pre-requisites (one-time, manual):
-#   1. Create the swarmer-secret in the swarmer namespace:
-#        oc create secret generic swarmer-secret \
-#          --from-literal=SWARMER_SECRET_KEY=$(python3 -c \
-#            "import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())") \
-#          -n swarmer --dry-run=client -o yaml | oc apply -f -
-#
-#   2. After first sync, patch the OAuthClient redirect URI and set OPENSHIFT_OAUTH_URL:
-#        SWARMER_HOST=$(oc get route swarmer -n swarmer -o jsonpath='{.spec.host}')
-#        oc patch oauthclient swarmer --type=json \
-#          -p "[{\"op\":\"replace\",\"path\":\"/redirectURIs/0\",\"value\":\"https://${SWARMER_HOST}/auth/callback\"}]"
-#        oc set env deployment/swarmer -n swarmer \
-#          OPENSHIFT_OAUTH_URL=https://$(oc get route oauth-openshift -n openshift-authentication -o jsonpath='{.spec.host}')
+# Pre-requisite (one-time, manual):
+#   Create the swarmer-secret in the swarmer namespace:
+#     oc create secret generic swarmer-secret \
+#       --from-literal=SWARMER_SECRET_KEY=$(python3 -c \
+#         "import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())") \
+#       -n swarmer --dry-run=client -o yaml | oc apply -f -
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
@@ -44,6 +37,11 @@ patches:
         value:
           name: DEFAULT_AGENT_TOOL
           value: "opencode"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: OPENSHIFT_OAUTH_URL
+          value: "https://oauth.apps.rosa.hcmaii01ue1.a9ro.p3.openshiftapps.com"
   - target:
       group: oauth.openshift.io
       version: v1
@@ -52,3 +50,6 @@ patches:
     patch: |
       - op: remove
         path: /metadata/namespace
+      - op: replace
+        path: /redirectURIs/0
+        value: "https://swarmer-swarmer.apps.rosa.hcmaii01ue1.a9ro.p3.openshiftapps.com/auth/callback"


### PR DESCRIPTION
## Summary

- The OAuthClient redirect URI placeholder (`SWARMER_HOST`) and `OPENSHIFT_OAUTH_URL` env var were previously manual post-deploy steps, causing a permanent OutOfSync diff in ArgoCD.
- Moves both into the hcmaii kustomize overlay so ArgoCD manages them declaratively:
  - OAuthClient redirect URI set to `https://swarmer-swarmer.apps.rosa.hcmaii01ue1.a9ro.p3.openshiftapps.com/auth/callback`
  - `OPENSHIFT_OAUTH_URL` set to `https://oauth.apps.rosa.hcmaii01ue1.a9ro.p3.openshiftapps.com`

## Test plan

- [x] `oc kustomize agent-swarm/overlays/hcmaii` renders OAuthClient with correct redirect URI
- [x] `oc kustomize agent-swarm/overlays/hcmaii` renders Deployment with `OPENSHIFT_OAUTH_URL`
- [ ] `hcm-ai-agent-swarm` transitions to fully Synced / Healthy


💘 Generated with Crush