### PR TITLE
fix: remove responseTypes from OAuthClient to eliminate ArgoCD diff

### DIFF
--- a/agent-swarm/base/oauth-client.yaml
+++ b/agent-swarm/base/oauth-client.yaml
@@ -9,5 +9,3 @@ redirectURIs:
   - https://SWARMER_HOST/auth/callback
   - http://localhost:8080/auth/callback
 grantMethod: auto
-responseTypes:
-  - token


### PR DESCRIPTION
## Summary

- The OpenShift API server strips `responseTypes` from OAuthClient objects after creation, but the kustomize manifest includes `responseTypes: [token]`. This causes a perpetual OutOfSync diff in ArgoCD.
- Removes `responseTypes` from the base OAuthClient manifest to match what the API server actually persists.

## Test plan

- [x] `oc kustomize agent-swarm/overlays/hcmaii` renders OAuthClient without `responseTypes`
- [ ] `hcm-ai-agent-swarm` OAuthClient transitions to Synced


💘 Generated with Crush