### PR TITLE
fix: correct OPENSHIFT_OAUTH_URL for ROSA HCP cluster

### DIFF
--- a/agent-swarm/overlays/hcmaii/kustomization.yaml
+++ b/agent-swarm/overlays/hcmaii/kustomization.yaml
@@ -41,7 +41,7 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: OPENSHIFT_OAUTH_URL
-          value: "https://oauth.apps.rosa.hcmaii01ue1.a9ro.p3.openshiftapps.com"
+          value: "https://oauth.hcmaii01ue1.a9ro.p3.openshiftapps.com:443"
   - target:
       group: oauth.openshift.io
       version: v1


### PR DESCRIPTION
## Summary

- ROSA HCP hosts the OAuth server externally at `oauth.hcmaii01ue1.a9ro.p3.openshiftapps.com:443`, not at `oauth.apps.rosa...` (there is no in-cluster OAuth server on HCP).
- Corrects `OPENSHIFT_OAUTH_URL` in the overlay, discovered via `/.well-known/oauth-authorization-server`.

## Test plan

- [ ] "Sign in with OpenShift" on swarmer dashboard redirects to the correct OAuth endpoint and completes login


💘 Generated with Crush