### PR TITLE
chore: bump swarmer image to 0.4.1

### DIFF
--- a/agent-swarm/overlays/hcmaii/kustomization.yaml
+++ b/agent-swarm/overlays/hcmaii/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
 images:
   - name: SWARMER_IMAGE
     newName: quay.io/jpacker/swarmer
-    newTag: "0.4.0"
+    newTag: "0.4.1"
 
 patches:
   - target:


### PR DESCRIPTION
## Summary

- Bump swarmer image from `0.4.0` to `0.4.1`, which includes the rolebindings ClusterRole fix from stolostron/agent-swarm.

## Test plan

- [ ] Swarmer pod restarts with `0.4.1` image
- [ ] New workspace creation automatically grants anyuid SCC


💘 Generated with Crush