### PR TITLE
feat: add Qdrant vector database deployment

### DIFF
--- a/gitops-applications/qdrant.application.yaml
+++ b/gitops-applications/qdrant.application.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hcm-ai-qdrant
+  namespace: maas-config
+spec:
+  destination:
+    name: in-cluster
+  project: default
+  source:
+    path: qdrant/overlays/hcmaii
+    repoURL: 'https://github.com/app-sre/hcm-ai-playground'
+    targetRevision: main
+  syncPolicy:
+    automated:
+      selfHeal: true
+      allowEmpty: false
+    prune: false

--- a/qdrant/base/client-serviceaccount.yaml
+++ b/qdrant/base/client-serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: qdrant-client

--- a/qdrant/base/deployment.yaml
+++ b/qdrant/base/deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qdrant
+  labels:
+    app: qdrant
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: qdrant
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: qdrant
+    spec:
+      serviceAccountName: qdrant
+      containers:
+        - name: qdrant
+          image: QDRANT_IMAGE
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 6333
+              name: http
+            - containerPort: 6334
+              name: grpc
+          volumeMounts:
+            - name: qdrant-data
+              mountPath: /qdrant/storage
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 6333
+            initialDelaySeconds: 5
+            periodSeconds: 10
+        - name: oauth-proxy
+          image: OAUTH_PROXY_IMAGE
+          imagePullPolicy: Always
+          args:
+            - --provider=openshift
+            - --upstream=http://localhost:6333
+            - --https-address=:9443
+            - --cookie-secret-file=/etc/proxy/secrets/session_secret
+            - '--openshift-delegate-urls={"/": {"namespace": "qdrant", "resource": "services", "name": "qdrant", "verb": "get"}}'
+            - --tls-cert=/etc/tls/private/tls.crt
+            - --tls-key=/etc/tls/private/tls.key
+            - --openshift-service-account=qdrant
+            - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          ports:
+            - containerPort: 9443
+              name: proxy
+          readinessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+          volumeMounts:
+            - name: tls-secret
+              mountPath: /etc/tls/private
+            - name: cookie-secret
+              mountPath: /etc/proxy/secrets
+      volumes:
+        - name: qdrant-data
+          persistentVolumeClaim:
+            claimName: qdrant-data
+        - name: tls-secret
+          secret:
+            secretName: qdrant-tls
+        - name: cookie-secret
+          secret:
+            secretName: qdrant-proxy-cookie-secret

--- a/qdrant/base/kustomization.yaml
+++ b/qdrant/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: qdrant
+
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - client-serviceaccount.yaml
+  - rbac.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - route.yaml

--- a/qdrant/base/namespace.yaml
+++ b/qdrant/base/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: qdrant
+  labels:
+    app.kubernetes.io/name: qdrant
+    argocd.argoproj.io/managed-by: openshift-gitops

--- a/qdrant/base/pvc.yaml
+++ b/qdrant/base/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qdrant-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: gp3-csi

--- a/qdrant/base/rbac.yaml
+++ b/qdrant/base/rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: qdrant-client
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["qdrant"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: qdrant-client
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: qdrant-client
+subjects:
+  - kind: ServiceAccount
+    name: qdrant-client

--- a/qdrant/base/route.yaml
+++ b/qdrant/base/route.yaml
@@ -1,0 +1,13 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: qdrant
+spec:
+  to:
+    kind: Service
+    name: qdrant
+  port:
+    targetPort: proxy
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect

--- a/qdrant/base/service.yaml
+++ b/qdrant/base/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: qdrant
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: qdrant-tls
+spec:
+  type: ClusterIP
+  selector:
+    app: qdrant
+  ports:
+    - port: 9443
+      targetPort: 9443
+      name: proxy
+    - port: 6333
+      targetPort: 6333
+      name: http
+    - port: 6334
+      targetPort: 6334
+      name: grpc

--- a/qdrant/base/serviceaccount.yaml
+++ b/qdrant/base/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: qdrant
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.qdrant: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"qdrant"}}'

--- a/qdrant/overlays/hcmaii/kustomization.yaml
+++ b/qdrant/overlays/hcmaii/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+images:
+  - name: QDRANT_IMAGE
+    newName: docker.io/qdrant/qdrant
+    newTag: "v1.13.2"
+  - name: OAUTH_PROXY_IMAGE
+    newName: quay.io/openshift/origin-oauth-proxy
+    newTag: "4.16"


### PR DESCRIPTION
- Adds Qdrant vector database deployment following the agent-swarm base+overlays pattern
- Includes oauth-proxy sidecar for service account bearer token authentication via the `qdrant-client` SA
- 10Gi PVC on gp3-csi, reencrypt TLS route, ArgoCD Application for GitOps management
After the namespace is created, create the cookie secret before the deployment can start:
```bash
oc create secret generic qdrant-proxy-cookie-secret \
  --from-literal=session_secret=$(head -c 32 /dev/urandom | base64) \
  -n qdrant
```
- [ ] Verify `kustomize build qdrant/overlays/hcmaii/` produces valid manifests
- [ ] Deploy to cluster and confirm pod reaches Ready state
- [ ] Confirm route is accessible with `qdrant-client` SA bearer token
- [ ] Confirm unauthenticated requests are rejected
🤖 Generated with [Claude Code](https://claude.com/claude-code)