### PR TITLE
fix: mount Qdrant PVC at /qdrant for writable snapshots dir

### DIFF
--- a/qdrant/base/deployment.yaml
+++ b/qdrant/base/deployment.yaml
@@ -28,7 +28,7 @@ spec:
               name: grpc
           volumeMounts:
             - name: qdrant-data
-              mountPath: /qdrant/storage
+              mountPath: /qdrant
           resources:
             requests:
               memory: "256Mi"


### PR DESCRIPTION
- Changes the PVC mount from `/qdrant/storage` to `/qdrant`
- Qdrant needs to create both `storage/` and `snapshots/tmp/` subdirectories at startup
- Mounting only at `/qdrant/storage` left `snapshots/` on the read-only container filesystem, causing a `PermissionDenied` crash on OpenShift
- [ ] Verify pod starts without `PermissionDenied` crash
- [ ] Confirm both containers (qdrant + oauth-proxy) reach Ready state
- [ ] Validate Qdrant responds on `/readyz`
🤖 Generated with [Claude Code](https://claude.com/claude-code)