### PR TITLE
fix: mount Qdrant PVC at /data with storage path env vars

### DIFF
--- a/qdrant/base/deployment.yaml
+++ b/qdrant/base/deployment.yaml
@@ -26,9 +26,14 @@ spec:
               name: http
             - containerPort: 6334
               name: grpc
+          env:
+            - name: QDRANT__STORAGE__STORAGE_PATH
+              value: /data/storage
+            - name: QDRANT__STORAGE__SNAPSHOTS_PATH
+              value: /data/snapshots
           volumeMounts:
             - name: qdrant-data
-              mountPath: /qdrant
+              mountPath: /data
           resources:
             requests:
               memory: "256Mi"


### PR DESCRIPTION
- Moves PVC mount from `/qdrant` to `/data` — mounting at `/qdrant` overwrites the container's entrypoint and binaries
- Configures `QDRANT__STORAGE__STORAGE_PATH=/data/storage` and `QDRANT__STORAGE__SNAPSHOTS_PATH=/data/snapshots` so Qdrant uses the PVC for all writable state
- Tested in `qdrant-test` namespace — pod reaches 2/2 Ready with zero restarts for 4+ minutes
- [x] Deployed to `qdrant-test` namespace and verified 2/2 Ready, 0 restarts
- [ ] Verify fix in production `qdrant` namespace after merge
🤖 Generated with [Claude Code](https://claude.com/claude-code)