### PR TITLE
fix: pin crush-container image to explicit version tag

### DIFF
--- a/agent-swarm/overlays/hcmaii/kustomization.yaml
+++ b/agent-swarm/overlays/hcmaii/kustomization.yaml
@@ -31,7 +31,7 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: AGENT_IMAGE_CRUSH
-          value: "ghcr.io/gurnben/crush-container:latest"
+          value: "ghcr.io/gurnben/crush-container:0.57.0"
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "labels": ["dependencies", "renovate"],
+  "enabledManagers": ["kustomize", "custom.regex"],
+  "kustomize": {
+    "fileMatch": ["(^|/)kustomization\\.ya?ml$"]
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)kustomization\\.ya?ml$"],
+      "matchStrings": [
+        "value:\\s*\"(?<depName>(?!https?://)[a-z0-9.-]+/[^\":]+):(?<currentValue>\\d[^\"]*)\""
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "All image updates require human review",
+      "matchManagers": ["kustomize", "custom.regex"],
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Pin `ghcr.io/gurnben/crush-container` from `:latest` to `:0.57.0` in the hcmaii kustomize overlay
- All agent-swarm image references now use explicit semantic version tags
- Verified kustomize build succeeds with the updated tag

## Image audit
| Image | Tag (before) | Tag (after) | Status |
|-------|-------------|------------|--------|
| `quay.io/jpacker/swarmer` | `0.4.1` | `0.4.1` | Already pinned |
| `quay.io/jpacker/opencode` | `0.1.1` | `0.1.1` | Already pinned |
| `ghcr.io/gurnben/crush-container` | `latest` | `0.57.0` | **Pinned** |

## Test plan
- [x] `grep -r "latest" agent-swarm/` returns no results
- [x] `kustomize build agent-swarm/overlays/hcmaii/` succeeds
- [x] All image references use explicit semver tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)