### PR TITLE
Add jkyros as admin of qdrant namespace

### DIFF
--- a/qdrant/base/kustomization.yaml
+++ b/qdrant/base/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - route.yaml
+  - user-jkyros-admin.yaml

--- a/qdrant/base/user-jkyros-admin.yaml
+++ b/qdrant/base/user-jkyros-admin.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jkyros-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: jkyros


### PR DESCRIPTION
Adds a RoleBinding granting user `jkyros` the `admin` ClusterRole in the `qdrant` namespace.